### PR TITLE
Added suport for automatically adding content warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,44 @@ When enabled, retweets are forwarded using the `retweet.tmpl` file as a template
 
 To create a link to the original tweet, use `https://twitter.com/%(user)s/status/%(id)s`.  To link to the original author profile, use `https://twitter.com/%(user)s`.
 
+## Content Warnings
+
+Content warnings can be added automatically to toots based on regular
+expressions. These are configured by creating a file named cw.json.
+
+For example, simple patterns can be used to match any tweet mentioning specific
+keywords:
+	{
+		"coding": [
+			"code", "coding", "pull request", "github", "git", "json", "regex"
+		],
+
+		"coffee": [
+			"#coffee", "coffee", "caffeine"
+		]
+	}
+
+If a regex pattern contains a group then that group will be used as the content
+warning text. This allows rules such as using the first hashtag of a tweet as
+the CW warning:
+	{
+		"hashtag-prefix": [
+			"^(#[^\\s]*)\\s"
+		]
+	}
+
+This also allows using a prefix such as CW to specify that the first line of a
+tweet should be used as the content warning:
+	{
+		"cw-prefix": [
+			"^CW (.*)\\n"
+		]
+	}
+
+Note that the regex is matched after the `retweet.tmpl` file is applied as a
+template, so this can be used to automatically apply a content warning to all
+RTs, or RTs from specific people, etc.
+
 # Licence
 
     Copyright (C) 2017  Laurent Peuch and [Contributors](https://github.com/Psycojoker/t2m/graphs/contributors)

--- a/t2m
+++ b/t2m
@@ -9,6 +9,7 @@ import time
 import shutil
 import tempfile
 import codecs
+import re
 
 try:
     from urllib import urlretrieve
@@ -27,6 +28,13 @@ try:
     from HTMLParser import HTMLParser
 except ImportError:
     from html.parser import HTMLParser
+
+
+def get_cws():
+    if os.path.exists("cw.json"):
+        return json.load(open("cw.json", "r"))
+
+    return {}
 
 
 def get_db():
@@ -119,8 +127,29 @@ def forward(db, twitter_handle, mastodon_handle, debug, number=None, only_mark_a
 
         if not only_mark_as_seen:
             h = HTMLParser()
+            t = h.unescape(text);
+            w = None
+
+            cws = get_cws()
+            for cw in cws.keys():
+                for pattern in cws[cw]:
+                    if w:
+                        break
+
+                    m = re.search(pattern=pattern, string=t)
+                    if m:
+                        try:
+                            # If there is a group in the re then use it
+                            w = m.group(1)
+                            t = re.sub(pattern, "", t)
+
+                        except:
+                            # If no group then use the key from the json
+                            w = cw
+
             to_toot.append({
-                "text": h.unescape(text),
+                "text": t,
+                "cw": w,
                 "id": i.id,
                 "medias": [x.media_url for x in media] if media else []
             })
@@ -148,7 +177,7 @@ def forward(db, twitter_handle, mastodon_handle, debug, number=None, only_mark_a
                         urlretrieve(media_url, dl_file_path)
                         medias.append((mastodon.media_post(dl_file_path))["id"])
 
-                    response = mastodon.status_post(toot["text"], media_ids=medias)
+                    response = mastodon.status_post(toot["text"], media_ids=medias, spoiler_text=toot["cw"])
                     assert not response.get("error"), response
                     forwarded += 1
                 except Exception as e:


### PR DESCRIPTION
This change adds support for configuring rules in a JSON document for
content warnings that should be applied when posting a toot to Mastodon.

The rules can either be a simple regex match against the text of a
tweet, or can include a group to allow using part of the text of the
tweet to be the text of the content warning.

The patterns are compared after applying the retweet.tmpl template which
allows things like automatically adding a content warning that specifies
the name of the twitter user being RTed.

The README.md has also been updated witn usage instructions and examples